### PR TITLE
telemetry decorator, staggering

### DIFF
--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/__init__.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/__init__.py
@@ -1,0 +1,25 @@
+import asyncio
+
+routines: dict[function, int] = {}
+
+
+def measurement(freq: int):
+    """
+    Marks a measurement, takes a frequency (in ms) to repeat the measurement.
+    """
+
+    def wrapper(fn: function):
+        routines[fn] = freq
+        return fn  # return the function unmodified so manual calls still work
+
+    return wrapper
+
+
+async def set_interval(fn: function, interval: int, *args, **kwargs):
+    """
+    Behaves *like* JS' `setInterval`, but intervals cannot be canceled.
+    """
+
+    while True:
+        await fn(*args, **kwargs)
+        await asyncio.sleep(interval * 1000)

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/__init__.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 
-routines: dict[function, int] = {}
+routines = {}
 
 
 def measurement(freq: int):
@@ -8,14 +8,14 @@ def measurement(freq: int):
     Marks a measurement, takes a frequency (in ms) to repeat the measurement.
     """
 
-    def wrapper(fn: function):
+    def wrapper(fn):
         routines[fn] = freq
         return fn  # return the function unmodified so manual calls still work
 
     return wrapper
 
 
-async def set_interval(fn: function, interval: int, *args, **kwargs):
+async def set_interval(fn, interval: int, *args, **kwargs):
     """
     Behaves *like* JS' `setInterval`, but intervals cannot be canceled.
     """

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/__init__.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/__init__.py
@@ -15,11 +15,14 @@ def measurement(freq: int):
     return wrapper
 
 
-async def set_interval(fn, interval: int, *args, **kwargs):
+async def set_interval(fn, interval: int, stop: asyncio.Event, *args, **kwargs):
     """
-    Behaves *like* JS' `setInterval`, but intervals cannot be canceled.
+    Behaves *like* JS' `setInterval`:
+    Run the function fn every interval milliseconds, and yield the result.
+    Stop when the stop event is set.
+    Uses the rest of the given args and kwargs for the function itself.
     """
 
-    while True:
-        await fn(*args, **kwargs)
-        await asyncio.sleep(interval * 1000)
+    while not stop.is_set():
+        yield fn(*args, **kwargs)
+        await asyncio.sleep(interval / 1000)

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/__init__.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/__init__.py
@@ -1,4 +1,4 @@
 # This file looks like it does nothing, but only things
 # that get imported here are going to get run as measurement routines.
 
-from . import can, example, halow, on_board
+from . import can as _, example as _, halow as _, on_board as _

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/__init__.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/__init__.py
@@ -1,0 +1,4 @@
+# This file looks like it does nothing, but only things
+# that get imported here are going to get run as measurement routines.
+
+from . import can, example, halow, on_board

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/can.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/can.py
@@ -1,7 +1,11 @@
 from subprocess import check_output
-FETCH_CMD = "bmon -o format:quitafter=1 -p can0"
-#example = "can0 0 11024 0 40"
+from telemetry import measurement
 
+FETCH_CMD = "bmon -o format:quitafter=1 -p can0"
+# example = "can0 0 11024 0 40"
+
+
+@measurement(100)
 def fetch_data():
     try:
         out = check_output(FETCH_CMD.split(" "), shell=False).decode("utf-8")
@@ -13,10 +17,9 @@ def fetch_data():
         return []
 
 
-
 def main():
     print(fetch_data())
 
+
 if __name__ == "__main__":
     main()
-    

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/can.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/can.py
@@ -1,5 +1,5 @@
 from subprocess import check_output
-from telemetry import measurement
+from .. import measurement
 
 FETCH_CMD = "bmon -o format:quitafter=1 -p can0"
 # example = "can0 0 11024 0 40"

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/example.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/example.py
@@ -1,4 +1,16 @@
+from telemetry import measurement
+
+
+@measurement(500)
 def fetch_data():
-    return [('TPU/Example/Data1', ['114'], 'C'), ('TPU/Example/Data1', ['1431242'], 'D'), ('TPU/Example/Data1', ['1431242'], 'Q'), ('TPU/Example/Data1', ['112343122'], 'X'), ('TPU/Example/Data1', ['112341232'], 'M'), ('TPU/Example/Data1', ['1413242'], 'W'),]
+    return [
+        ("TPU/Example/Data1", ["114"], "C"),
+        ("TPU/Example/Data1", ["1431242"], "D"),
+        ("TPU/Example/Data1", ["1431242"], "Q"),
+        ("TPU/Example/Data1", ["112343122"], "X"),
+        ("TPU/Example/Data1", ["112341232"], "M"),
+        ("TPU/Example/Data1", ["1413242"], "W"),
+    ]
+
 
 # fetch_data() # returns List[(str, [str], str)] in the format (topic, values, unit)

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/example.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/example.py
@@ -1,4 +1,4 @@
-from telemetry import measurement
+from .. import measurement
 
 
 @measurement(500)

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/halow.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/halow.py
@@ -1,5 +1,5 @@
 from subprocess import check_output
-from telemetry import measurement
+from .. import measurement
 
 example_data = """BSSID         BW          TX bit rate        RX bit rate
 =====================================================================
@@ -18,7 +18,18 @@ SNR                              : 0
 OK"""
 FETCH_RSSI_CMD = "cli_app show stats simple_rx"
 FETCH_RATE_CMD = "cli_app show ap 0"
+FETCH_THROUGHPUT_CMD = "bmon -o format:quitafter=1 -p wlan1"
 
+@measurement(100)
+def fetch_data_Throughput():
+    try:
+        out = check_output(FETCH_THROUGHPUT_CMD.split(" "), shell=False).decode("utf-8")
+        split = out.split(" ")
+        data = [split[4].strip(), split[2].strip()]
+        return [("TPU/HaLow/DataRate", data, "kb/s")]
+    except Exception as e:
+        print(f"Error fetching data: {e}")
+        return []
 
 @measurement(500)
 def fetch_data_ApMCS():
@@ -57,10 +68,11 @@ def fetch_data_RSSI():
 
 
 def fetch_data():
-    return fetch_data_ApMCS() + fetch_data_StaMCS() + fetch_data_RSSI()
+    return fetch_data_Throughput() + fetch_data_ApMCS() + fetch_data_StaMCS() + fetch_data_RSSI()
 
 
 def main():
+    print(fetch_data_Throughput())
     print(fetch_data_ApMCS())
     print(fetch_data_StaMCS())
     print(fetch_data_RSSI())

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/halow.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/halow.py
@@ -1,4 +1,6 @@
 from subprocess import check_output
+from telemetry import measurement
+
 example_data = """BSSID         BW          TX bit rate        RX bit rate
 =====================================================================
 00:00:00:00:00:00     1M        0.33MBit/s(MCS 0)   0.33MBit/s(MCS 0)
@@ -17,28 +19,33 @@ OK"""
 FETCH_RSSI_CMD = "cli_app show stats simple_rx"
 FETCH_RATE_CMD = "cli_app show ap 0"
 
+
+@measurement(500)
 def fetch_data_ApMCS():
     try:
         out = check_output(FETCH_RATE_CMD.split(" "), shell=False).decode("utf-8")
-        data_line = out.splitlines()[2] 
+        data_line = out.splitlines()[2]
         parsed_data = data_line.split()[5][:-1].strip()
         return [("TPU/HaLow/ApMCS", [parsed_data], "integer 0-10")]
     except Exception as e:
         print(f"Error fetching data: {e}")
         return []
 
+
+@measurement(500)
 def fetch_data_StaMCS():
     try:
         out = check_output(FETCH_RATE_CMD.split(" "), shell=False).decode("utf-8")
-        data_line = out.splitlines()[2] 
+        data_line = out.splitlines()[2]
         parsed_data = data_line.split()[3][:-1].strip()
         return [("TPU/HaLow/StaMCS", [parsed_data], "integer 0-10")]
     except Exception as e:
         print(f"Error fetching data: {e}")
         return []
 
-def fetch_data_RSSI():
 
+@measurement(500)
+def fetch_data_RSSI():
     try:
         out = check_output(FETCH_RSSI_CMD.split(" "), shell=False).decode("utf-8")
         split = out.splitlines()[1]
@@ -48,14 +55,16 @@ def fetch_data_RSSI():
         print(f"Error fetching data: {e}")
         return []
 
+
 def fetch_data():
     return fetch_data_ApMCS() + fetch_data_StaMCS() + fetch_data_RSSI()
+
 
 def main():
     print(fetch_data_ApMCS())
     print(fetch_data_StaMCS())
     print(fetch_data_RSSI())
 
+
 if __name__ == "__main__":
     main()
-    

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/on_board.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/on_board.py
@@ -1,4 +1,4 @@
-from telemetry import measurement
+from .. import measurement
 import psutil
 
 # fetch_data() -> List[(str, [str], str)]
@@ -14,7 +14,7 @@ def fetch_data():
 
 
 # CPU Temp
-@measurement(100)
+@measurement(2000)
 def fetch_cpu_temperature():
     try:
         temps = psutil.sensors_temperatures(fahrenheit=False)
@@ -58,7 +58,7 @@ def fetch_broker_cpu_usage():
 
 
 # CPU available memory
-@measurement(50)
+@measurement(500)
 def fetch_available_memory():
     try:
         mem_info = psutil.virtual_memory()

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/on_board.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/poll_data/on_board.py
@@ -1,14 +1,20 @@
-
+from telemetry import measurement
 import psutil
 
 # fetch_data() -> List[(str, [str], str)]
 
+
 def fetch_data():
-    return fetch_cpu_temperature() + fetch_cpu_usage() + fetch_broker_cpu_usage() + fetch_available_memory()
-    
+    return (
+        fetch_cpu_temperature()
+        + fetch_cpu_usage()
+        + fetch_broker_cpu_usage()
+        + fetch_available_memory()
+    )
 
 
 # CPU Temp
+@measurement(100)
 def fetch_cpu_temperature():
     try:
         temps = psutil.sensors_temperatures(fahrenheit=False)
@@ -20,47 +26,52 @@ def fetch_cpu_temperature():
                     entry.high,
                     entry.critical,
                 )
-        return[("TPU/OnBoard/CpuTemp", [str(entry.current)], "celsius")]
+        return [("TPU/OnBoard/CpuTemp", [str(entry.current)], "celsius")]
     except Exception as e:
         print(f"Error fetching system temperature: {e}")
         return []
-    
-    
 
-# CPU Usage 
+
+# CPU Usage
+@measurement(50)
 def fetch_cpu_usage():
     try:
         cpu_usage = psutil.cpu_percent()
-        return[("TPU/OnBoard/CpuUsage", [str(cpu_usage)], "percent")]
+        return [("TPU/OnBoard/CpuUsage", [str(cpu_usage)], "percent")]
     except Exception as e:
         print(f"Error fetching CPU usage: {e}")
         return []
 
+
 # CPU usage of nanomq process
+@measurement(100)
 def fetch_broker_cpu_usage():
     try:
-        with open('/var/run/mosquitto.pid', 'r') as file:
+        with open("/var/run/mosquitto.pid", "r") as file:
             pid = int(file.read())
             process = psutil.Process(pid)
             broker_cpu_usage = process.cpu_percent()
-        return[("TPU/OnBoard/BrokerCpuUsage", [str(broker_cpu_usage)], "percent")]
+        return [("TPU/OnBoard/BrokerCpuUsage", [str(broker_cpu_usage)], "percent")]
     except Exception as e:
         print(f"Error fetching broker CPU usage: {e}")
         return []
 
+
 # CPU available memory
+@measurement(50)
 def fetch_available_memory():
     try:
         mem_info = psutil.virtual_memory()
-        mem_available = mem_info.available / (1024 * 1024)  
-        return[("TPU/OnBoard/MemAvailable", [str(mem_available)], "MB")]
+        mem_available = mem_info.available / (1024 * 1024)
+        return [("TPU/OnBoard/MemAvailable", [str(mem_available)], "MB")]
     except Exception as e:
         print(f"Error fetching available memory: {e}")
         return []
-    
+
+
 def main():
     print(fetch_data())
 
+
 if __name__ == "__main__":
     main()
-    

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -1,6 +1,6 @@
 import asyncio
 import signal
-from telemetry import routines, set_interval
+from . import routines, set_interval
 from gmqtt import Client as MQTTClient
 
 # initialize connection

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -1,6 +1,10 @@
 import asyncio
 import signal
-from . import routines, set_interval
+from . import (
+    routines,
+    set_interval,
+    poll_data,  # your editor lies, this is an important import.
+)
 from gmqtt import Client as MQTTClient
 
 # initialize connection
@@ -29,8 +33,6 @@ async def run(host):
     await client.connect(host, 1883)
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
-
-    print(routines)
 
     stagger = 1 / len(routines)
 

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -41,8 +41,7 @@ async def run(host):
         asyncio.threads.to_thread(lambda: set_interval(fn, freq))
         await asyncio.sleep(stagger)
 
-    while True:
-        await asyncio.sleep(0.5)
+    await STOP.wait()
 
 
 def main():

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -1,7 +1,7 @@
 import asyncio
 import signal
-from telemetry import server_data_pb2
 from . import (
+    server_data_pb2,
     routines,
     set_interval,
     poll_data as _,  # your editor lies, this is an important import.
@@ -65,7 +65,7 @@ async def run(host):
 def main():
     loop = asyncio.new_event_loop()
 
-    host = "broker.emqx.io"
+    host = "localhost"
 
     loop.add_signal_handler(signal.SIGINT, ask_exit)
     loop.add_signal_handler(signal.SIGTERM, ask_exit)

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -4,7 +4,7 @@ from telemetry import server_data_pb2
 from . import (
     routines,
     set_interval,
-    poll_data,  # your editor lies, this is an important import.
+    poll_data as _,  # your editor lies, this is an important import.
 )
 from gmqtt import Client as MQTTClient
 

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -1,73 +1,55 @@
 import asyncio
 import signal
-from telemetry import server_data_pb2
-from poll_data import example, can, on_board, halow
-#from gen_data import server_data_pb2
-import time
-import asyncio
+from telemetry import routines, set_interval
 from gmqtt import Client as MQTTClient
 
 # initialize connection
-
 client = MQTTClient("tpu-publisher")
-
 STOP = asyncio.Event()
 
+
 def on_connect(client, flags, rc, properties):
-    print('Connected')
+    print("Connected")
+
 
 def on_disconnect(client, packet, exc=None):
-    print('Disconnected')
-    
+    print("Disconnected")
+
+
 def ask_exit(*args):
     STOP.set()
+
 
 def publish_data(topic, message_data):
     # send the data
     client.publish(topic, message_data)
+
 
 async def run(host):
     await client.connect(host, 1883)
     client.on_connect = on_connect
     client.on_disconnect = on_disconnect
 
-    while True:
-        items = can.fetch_data() + halow.fetch_data() + on_board.fetch_data()
+    print(routines)
 
-        for file_data in items:
-            print(file_data)
-            topic = file_data[0]
+    stagger = 1 / len(routines)
 
-            data = server_data_pb2.ServerData()
-
-            data.unit = file_data[2]
-
-            values = file_data[1]
-            for val in values:
-                data.value.append(val)
-            
-            message_data = data.SerializeToString()
-            
-            publish_data(topic, message_data)
-            
-        if STOP.is_set():
-            await client.disconnect()
-            return
-
-        await asyncio.sleep(1)
-
-    await STOP.wait()
+    for fn in routines:
+        freq = routines[fn]
+        asyncio.threads.to_thread(lambda: set_interval(fn, freq))
+        await asyncio.sleep(stagger)
 
 
 def main():
     loop = asyncio.new_event_loop()
-    
-    host = '127.0.0.1'
+
+    host = "broker.emqx.io"
 
     loop.add_signal_handler(signal.SIGINT, ask_exit)
     loop.add_signal_handler(signal.SIGTERM, ask_exit)
 
     loop.run_until_complete(run(host))
-    
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     main()

--- a/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
+++ b/odysseus/odysseus_tree/sources/tpu_telemetry/telemetry/publish.py
@@ -39,6 +39,9 @@ async def run(host):
         asyncio.threads.to_thread(lambda: set_interval(fn, freq))
         await asyncio.sleep(stagger)
 
+    while True:
+        await asyncio.sleep(0.5)
+
 
 def main():
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
## Changes

Added a `@measurement(ms)` decorator to make it easier to add further measurements and run them at custom frequencies.

Also staggers beginning measurements over the first second of execution.

## Notes

Not tested at all since I couldn't figure out how to get it to run.

## To Do

_Any remaining things that need to get done_

- [ ] See if it works

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
- [x] PR is linked to the ticket (fill in the closes line below)

Closes #117.
