### PR TITLE
Fix gps being incorrectly configured

### DIFF
--- a/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/chrony.conf
+++ b/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/chrony.conf
@@ -1,13 +1,14 @@
 pool pool.ntp.org iburst
 driftfile /var/lib/chrony/drift
 
-makestep 1.0 3
-rtcsync
+makestep 1.0 50
 hwtimestamp *
 allow
 
 logdir /var/log/chrony
 
 
-refclock SOCK /run/chrony.ttyAMA5.sock refid GPS precision 1e-1 offset 0.9999
-refclock SOCK /run/chrony.pps0.sock refid PPS precision 1e-7 
+#refclock SOCK /var/run/chrony.ttyAMA5.sock refid GPS precision 1e-1 offset 0.9999
+#refclock SOCK /run/chrony.pps0.sock    refid PPS precision 1e-7
+refclock SHM 0 refid GPS poll 0 precision 1e-1 offset 0.5 delay 0.2
+refclock SHM 1 refid PPS poll 0 precision 1e-7 pps trust

--- a/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/init.d/S50gpsd
+++ b/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/init.d/S50gpsd
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# NER: copied from br source and edited
+# Starts the gps daemon.
+#
+
+NAME=gpsd
+DAEMON=/usr/sbin/$NAME
+DEVICES="/dev/pps0 /dev/ttyAMA5"
+PIDFILE=/var/run/$NAME.pid
+
+start() {
+        printf "Starting $NAME: "
+        # add -n option to run w/o waiting and -r option to allow time w/o fix
+        start-stop-daemon -S -q -p $PIDFILE --exec $DAEMON -- -P $PIDFILE $DEVICES -n -r && echo "OK" || echo "Failed"
+}
+stop() {
+        printf "Stopping $NAME: "
+        start-stop-daemon -K -q -p $PIDFILE && echo "OK" || echo "Failed"
+        rm -f $PIDFILE
+}
+restart() {
+        stop
+        start
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart|reload)
+        restart
+        ;;
+  *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+esac
+
+exit $?

--- a/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/init.d/S51ublox-settings
+++ b/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/init.d/S51ublox-settings
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+start() {
+        printf "Setting ublox settings"
+        # turn on PPS w/o fix
+        ubxtool -P 18 -v 2 -p CFG-TP5,0,2,0,1000000,1000000,100000,100000,0,0x77 --device /dev/ttyAMA5 >> /dev/null &
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  *)
+        echo "Usage: $0 {start}"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Changes

Copies the gpsd init script from buildroot with out flags and fixes.  Switch to SHM over unix sockets because they are easily debuggable and seem be working consistently so far.  Sets PPS on at boot bc the NEO-M8Q doesn't have flash storage.

## Notes

The gpsd devices flag is now ignored.

## Test Cases

- System boots w/o gps fix and sets time within about 10 seconds


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #75 
