### PR TITLE
Bidrectionality in Siren at Software's Request

### DIFF
--- a/extra/emqx_base/README.md
+++ b/extra/emqx_base/README.md
@@ -5,3 +5,6 @@ Clone repo and cd to this directory.
 
 run with (note: absolute paths must be used):  
 `docker run -d --restart=always --name emqx -p 18083:18083 -p 1883:1883 -p 14567:14567/udp -v /path/to/emqx.conf:/opt/emqx/etc/emqx.conf -v /path/to/listeners.quic.conf:/opt/emqx/etc/listeners.quic.conf -v /path/to/listeners.tcp.conf:/opt/emqx/etc/listeners.tcp.conf emqx:5.5.0`
+
+Ex.  
+`docker run -d --restart=always --name emqx -p 18083:18083 -p 1883:1883 -p 14567:14567/udp -v /opt/Odysseus/extra/emqx_base/emqx.conf:/opt/emqx/etc/emqx.conf -v /opt/Odysseus/extra/emqx_base/listeners.quic.conf:/opt/emqx/etc/listeners.quic.conf -v /opt/Odysseus/extra/emqx_base/listeners.tcp.conf:/opt/emqx/etc/listeners.tcp.conf emqx:5.5.0`

--- a/extra/mosquitto_base/README.md
+++ b/extra/mosquitto_base/README.md
@@ -6,7 +6,8 @@ All of the steps should be done in the ssh console of the base station, with IP 
 3. run the below command.  note that the path to the moquitto.conf in this directory **must be absolute**.
 
 `docker run --restart=always -it -p 1883:1883 -p 9001:9001 -v /path/to/mosquitto.conf:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log -d eclipse-mosquitto`
-
+Ex.  
+`docker run --restart=always -it -p 1883:1883 -p 9001:9001 -v /opt/Odysseus/extra/mosquitto_base/mosquitto.conf:/mosquitto/config/mosquitto.conf -v /mosquitto/data -v /mosquitto/log -d eclipse-mosquitto`
 
 ### Tips and tricks
 

--- a/extra/mosquitto_base/mosquitto.conf
+++ b/extra/mosquitto_base/mosquitto.conf
@@ -169,8 +169,9 @@ connection tpu
 # *** tpu ip
 # *** diff from tpu
 address 192.168.100.12
-# below is not a comment !!! #***
-topic # both 0 "" ""
+# *** diff from tpu (needed as topic key required)
+topic reserved out 2 dummy dummyremote
+
 
 #bridge_bind_address
 

--- a/extra/mosquitto_base/mosquitto.conf
+++ b/extra/mosquitto_base/mosquitto.conf
@@ -169,8 +169,8 @@ connection tpu
 # *** tpu ip
 # *** diff from tpu
 address 192.168.100.12
-# *** diff from tpu (needed as topic key required)
-topic reserved out 2 dummy dummyremote
+# below is not a comment !!! #***
+topic # both 0 "" ""
 
 #bridge_bind_address
 

--- a/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/mosquitto/mosquitto.conf
+++ b/odysseus/odysseus_tree/overlays/rootfs_overlay_tpu/etc/mosquitto/mosquitto.conf
@@ -167,7 +167,7 @@ connection base_station
 # *** base station ip
 address 192.168.100.1
 # below is not a comment !!! #***
-topic # out 0 "" ""
+topic # both 0 "" ""
 
 #bridge_bind_address
 


### PR DESCRIPTION
## Changes

Adds Siren bidrectionality for mosquitto.

## Notes

This is very dangerous in that infinite loops could occur if one bridge subscribes to the same topic it s publishing to under MQTTv3.0.  **Therefore all messages really have to be MQTTv5 after this PR**.

## Test Cases

- Could send from router side and recieve on TPU
- No infinite loops occured in any MQTTv5 messages sent.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] All commits are tagged with the ticket number
- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes #111 
