### PR TITLE
Initial Implementation of Live Resizing

### DIFF
--- a/odysseus/odysseus_tree/board/ap/cmdline.txt
+++ b/odysseus/odysseus_tree/board/ap/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rootwait console=tty1 console=serial0,115200
+root=/dev/mmcblk0p2 rootwait console=tty1 console=serial0,115200 init=/sbin/ody-resize

--- a/odysseus/odysseus_tree/board/iroh/cmdline.txt
+++ b/odysseus/odysseus_tree/board/iroh/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rootwait console=tty1 console=serial0,115200
+root=/dev/mmcblk0p2 rootwait console=tty1 console=serial0,115200 init=/sbin/ody-resize

--- a/odysseus/odysseus_tree/board/tpu/cmdline.txt
+++ b/odysseus/odysseus_tree/board/tpu/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rootwait console=tty1
+root=/dev/mmcblk0p2 rootwait console=tty1 init=/sbin/ody-resize part

--- a/odysseus/odysseus_tree/board/tpu/cmdline.txt
+++ b/odysseus/odysseus_tree/board/tpu/cmdline.txt
@@ -1,1 +1,1 @@
-root=/dev/mmcblk0p2 rootwait console=tty1 init=/sbin/ody-resize part
+root=/dev/mmcblk0p2 rootwait console=tty1 init=/sbin/ody-resize

--- a/odysseus/odysseus_tree/overlays/rootfs_overlay_common/sbin/ody-resize
+++ b/odysseus/odysseus_tree/overlays/rootfs_overlay_common/sbin/ody-resize
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+ROOT_DISK=/dev/mmcblk0
+ROOT_PART=/dev/mmcblk0p2
+
+BOOT_PART=/dev/mmcblk0p1
+
+echo "ODY RESIZE - Entering"
+
+# mount boot partition, for live user only!
+do_bootmnt() {
+    echo "ODY RESIZE - Mounting Boot"
+    mkdir /boot
+    mount "$BOOT_PART" /boot
+
+}
+
+# restore inittab init capability
+do_restore() {
+    echo "ODY RESIZE - Restoring"
+    sed -i 's| init=/sbin/ody-resize||' /boot/cmdline.txt # delete the init field
+    sync
+}
+
+# unmount and reboot
+do_reboot() {
+    sync
+    umount /boot
+    umount /
+    sync
+    reboot -f # skip init!
+}
+
+# trigger this script to be init on next boot
+do_trigger() {
+    echo "ODY RESIZE - Triggering"
+    sed -i '/1/s/$/ init=\/sbin\/ody-resize/' /boot/cmdline.txt # add back the init to the end of line one
+    rm /boot/stage2 # remove the stage2 flag so stage1 starts on next boot
+    sync
+}
+
+# resize the 2nd partition to maximum size available, and prep for stage 2
+part_root() {
+    sync
+    echo "ODY RESIZE - Partitioning"
+    echo ",+" | sfdisk -N 2 "$ROOT_DISK" --no-reread # expand to max size, no-reread as mmcblk0 is mounted
+    
+    # note that partitioning is done
+    touch /boot/stage2
+    do_reboot
+} 
+
+# resize the 2nd partition to maximum size available, and restore
+resize_root() {
+    sync
+    echo "ODY RESIZE - Resizing FS"
+    resize2fs "$ROOT_PART"
+    
+    do_restore # boot normally next
+    
+    do_reboot
+} 
+
+main() {
+    mount -t proc proc /proc # mount proc as mtab is needed
+    mount -t sysfs sysfs /sys # mount sysfs as sfdisk needs alignment
+    mount -o rw /dev/mmcblk0p1 /boot # mount boot so we can set the stage2 flag
+    if [ -e boot/stage2 ];
+    then
+        mount -o remount,rw / # for some reason umount fails, so online resize instead
+        resize_root
+    else
+        umount / # for some reason umount fails, so online repartition is needed, should investigate more
+        part_root
+    fi
+    
+}
+
+# restore non-resize boot functionality (live only)
+if [ "$1" = "restore" ];
+then
+    do_bootmnt
+    do_restore
+# set resize on for next boot (live only)
+elif [ "$1" = "trigger" ];
+then
+    do_bootmnt
+    do_restore
+    do_trigger
+# mount boot partition (live only)
+elif [ "$1" = "bootmnt" ];
+then
+    do_bootmnt
+# run the main script, cannot be further divided as cmdline.txt
+else
+    main
+fi
+

--- a/odysseus/odysseus_tree/overlays/rootfs_overlay_common/sbin/ody-resize
+++ b/odysseus/odysseus_tree/overlays/rootfs_overlay_common/sbin/ody-resize
@@ -10,7 +10,6 @@ echo "ODY RESIZE - Entering"
 # mount boot partition, for live user only!
 do_bootmnt() {
     echo "ODY RESIZE - Mounting Boot"
-    mkdir /boot
     mount "$BOOT_PART" /boot
 
 }


### PR DESCRIPTION
## Changes

Live resize much to the style of rpiOS, but without all those darn safety checks because we can assume the root, boot, etc. filesystem naming schemas will never change.  Runs a partition expand, reboots, then runs a resize filesystem operation.  For some reason I cannot unmount root, probably due to buildroot being wierd with devtmpfs, thankfully sfdisk and resize2fs have online support.  

I had to add the boot folder to allow for boot mounting as the root partition cannot have such a folder added via the script, as when the script is run root is read only.

## Notes

This is a good platform by which to add other image mounting scripts for example if SD card ever works.  I am also exploring using this system for live imaging deploying by unpacking an sdcard image over another on the live system.

## Test Cases

- On first boot resizes to size of sdcard, takes approx 45 seconds to fully resize and finish boot normally
- doesnt run again



Closes #100 
